### PR TITLE
- fix deprecated call in openFile database browser

### DIFF
--- a/.project
+++ b/.project
@@ -1,0 +1,3 @@
+{
+	'srcDirectory' : 'repository'
+}

--- a/repository/PunQLite-Tools/PqDatabaseBrowser.class.st
+++ b/repository/PunQLite-Tools/PqDatabaseBrowser.class.st
@@ -296,11 +296,9 @@ PqDatabaseBrowser >> openDatabase: filename [
 { #category : #'private - actions' }
 PqDatabaseBrowser >> openFile [
     | filename |
-    filename := UITheme builder 
-                            fileOpen: 'Choose a .db file' 
-                            extensions: #('db').
+    filename := UITheme builder chooseExistingFileReference: 'Choose a .db file' extensions: #('db')path: '.'.
     filename isNil ifTrue:[ ^self ].
-    self openDatabase: filename name
+    self openDatabase: filename fullName
 ]
 
 { #category : #'private - actions' }


### PR DESCRIPTION
while toying with punqlite, I noticed that the db browser open function was using deprecated method.
I simply fixed them. The change to the .project file came automatically.